### PR TITLE
[Fix] v1.6.7 앱 세부 수정

### DIFF
--- a/SNAPY_iOS/Feature/Album/AlbumView.swift
+++ b/SNAPY_iOS/Feature/Album/AlbumView.swift
@@ -10,6 +10,7 @@ import SwiftUI
 struct AlbumView: View {
     @StateObject private var viewModel = AlbumViewModel()
     @ObservedObject private var photoStore = PhotoStore.shared
+    @Environment(\.scenePhase) private var scenePhase
 
     @State private var dragOffset: CGFloat = 0
     @State private var showCalendar = false
@@ -67,7 +68,16 @@ struct AlbumView: View {
             AlbumCalendarView()
         }
         .task {
+            viewModel.synchronizeCurrentDate()
+            viewModel.startObservingDayChange()
             await viewModel.loadSelectedDate()
+        }
+        .onDisappear {
+            viewModel.stopObservingDayChange()
+        }
+        .onChange(of: scenePhase) { _, phase in
+            guard phase == .active else { return }
+            viewModel.synchronizeCurrentDate()
         }
         .onChange(of: viewModel.selectedDate) { _, _ in
             viewModel.currentPage = TimeSlot.current.rawValue

--- a/SNAPY_iOS/Feature/Album/AlbumViewModel.swift
+++ b/SNAPY_iOS/Feature/Album/AlbumViewModel.swift
@@ -17,16 +17,31 @@ enum EmptySlotState {
 
 @MainActor
 final class AlbumViewModel: ObservableObject {
-    @Published var selectedDate: Date = Date()
+    @Published var selectedDate: Date
     @Published var currentPage: Int = TimeSlot.current.rawValue
     @Published var slideDirection: SlideDirection = .none
+
+    private let calendar: Calendar
+    private var lastKnownToday: Date
+    private var dayChangeTask: Task<Void, Never>?
+
+    init(calendar: Calendar = .current, now: Date = Date()) {
+        self.calendar = calendar
+        let today = calendar.startOfDay(for: now)
+        self._selectedDate = Published(initialValue: today)
+        self.lastKnownToday = today
+    }
+
+    deinit {
+        dayChangeTask?.cancel()
+    }
 
     enum SlideDirection {
         case none, left, right
     }
 
     private var isToday: Bool {
-        Calendar.current.isDateInToday(selectedDate)
+        calendar.isDateInToday(selectedDate)
     }
 
     var dateString: String {
@@ -73,18 +88,56 @@ final class AlbumViewModel: ObservableObject {
     func goToPreviousDay() {
         slideDirection = .right
         withAnimation(.easeInOut(duration: 0.3)) {
-            selectedDate = Calendar.current.date(byAdding: .day, value: -1, to: selectedDate) ?? selectedDate
+            selectedDate = calendar.date(byAdding: .day, value: -1, to: selectedDate) ?? selectedDate
         }
     }
 
     func goToNextDay() {
-        let tomorrow = Calendar.current.date(byAdding: .day, value: 1, to: selectedDate) ?? selectedDate
-        if tomorrow <= Date() {
+        let tomorrow = calendar.date(byAdding: .day, value: 1, to: selectedDate) ?? selectedDate
+        let today = calendar.startOfDay(for: Date())
+        if tomorrow <= today {
             slideDirection = .left
             withAnimation(.easeInOut(duration: 0.3)) {
                 selectedDate = tomorrow
             }
         }
+    }
+
+    /// 앱이 자정을 넘긴 경우, 기존에 보고 있던 오늘 앨범을 새 오늘 날짜로 갱신한다.
+    func synchronizeCurrentDate() {
+        let today = calendar.startOfDay(for: Date())
+        defer { lastKnownToday = today }
+
+        guard !calendar.isDate(lastKnownToday, inSameDayAs: today),
+              calendar.isDate(selectedDate, inSameDayAs: lastKnownToday) else {
+            return
+        }
+
+        selectedDate = today
+    }
+
+    func startObservingDayChange() {
+        dayChangeTask?.cancel()
+        dayChangeTask = Task { [weak self] in
+            while !Task.isCancelled {
+                guard let self else { return }
+                let nextDay = self.calendar.date(byAdding: .day, value: 1, to: self.calendar.startOfDay(for: Date())) ?? Date()
+                let nanoseconds = UInt64(max(nextDay.timeIntervalSinceNow, 1) * 1_000_000_000)
+
+                do {
+                    try await Task.sleep(nanoseconds: nanoseconds)
+                } catch {
+                    return
+                }
+
+                self.synchronizeCurrentDate()
+            }
+        }
+    }
+
+    func stopObservingDayChange() {
+        dayChangeTask?.cancel()
+        dayChangeTask = nil
     }
 
     /// 선택된 날짜의 앨범을 서버에서 로드
@@ -95,7 +148,7 @@ final class AlbumViewModel: ObservableObject {
             await PhotoStore.shared.loadAlbumById(albumId)
         } else {
             // monthAlbums 에 없으면 해당 월을 추가 로드 (기존 데이터 유지)
-            let month = Calendar.current.component(.month, from: selectedDate)
+            let month = calendar.component(.month, from: selectedDate)
             await PhotoStore.shared.appendMonth(month)
             // 다시 시도
             if let albumId = PhotoStore.shared.albumId(for: selectedDate) {

--- a/SNAPY_iOS/Feature/Friend/Component/FriendProfile/FriendProfileViewModel.swift
+++ b/SNAPY_iOS/Feature/Friend/Component/FriendProfile/FriendProfileViewModel.swift
@@ -215,6 +215,10 @@ final class FriendProfileViewModel: ObservableObject {
         do {
             let albums = try await AlbumService.shared.fetchAlbumsForUser(month: month, handle: handle)
             let sorted = albums.sorted { $0.albumDate > $1.albumDate }
+            async let postCountTask: Void = loadVisiblePostCount(
+                currentMonthAlbums: albums,
+                currentMonth: month
+            )
 
             let posts: [FeedPost] = await withTaskGroup(of: FeedPost?.self) { group in
                 for album in sorted {
@@ -245,10 +249,30 @@ final class FriendProfileViewModel: ObservableObject {
             }
 
             feedPosts = posts
-            postCount = posts.count
+            await postCountTask
         } catch {
             print("[FriendProfileVM] 피드 로드 실패: \(error)")
         }
+    }
+
+    /// 상대에게 공개된 과거 앨범과 이번 달 앨범을 모두 합산해 프로필 게시물 수를 계산한다.
+    private func loadVisiblePostCount(currentMonthAlbums: [AlbumListItemData], currentMonth: Int) async {
+        let pastMonths = Set(pastAlbums.map(\.month)).subtracting([currentMonth])
+        var allAlbums = currentMonthAlbums
+
+        await withTaskGroup(of: [AlbumListItemData].self) { group in
+            for month in pastMonths {
+                group.addTask { [handle] in
+                    (try? await AlbumService.shared.fetchAlbumsForUser(month: month, handle: handle)) ?? []
+                }
+            }
+
+            for await albums in group {
+                allAlbums.append(contentsOf: albums)
+            }
+        }
+
+        postCount = Set(allAlbums.map(\.albumId)).count
     }
 
     // MARK: - 과거 달 피드 로드

--- a/SNAPY_iOS/Feature/Home/Component/Story/StoryDetailView.swift
+++ b/SNAPY_iOS/Feature/Home/Component/Story/StoryDetailView.swift
@@ -18,7 +18,7 @@ enum StoryLikeCache {
     static func clear() { store.removeAll() }
 }
 
-private struct StoryProfileDestination: Identifiable {
+private struct StoryProfileDestination: Identifiable, Hashable {
     let handle: String
     let name: String
     let profileImageUrl: String?

--- a/SNAPY_iOS/Feature/Home/Component/Story/StoryDetailView.swift
+++ b/SNAPY_iOS/Feature/Home/Component/Story/StoryDetailView.swift
@@ -18,6 +18,14 @@ enum StoryLikeCache {
     static func clear() { store.removeAll() }
 }
 
+private struct StoryProfileDestination: Identifiable {
+    let handle: String
+    let name: String
+    let profileImageUrl: String?
+
+    var id: String { handle }
+}
+
 struct StoryDetailView: View {
     let stories: [StoryItem]
     let initialIndex: Int
@@ -26,7 +34,7 @@ struct StoryDetailView: View {
     @Environment(\.dismiss) private var dismiss
     @StateObject private var viewModel: StoryDetailViewModel
 
-    @State private var navProfileHandle: String? = nil
+    @State private var selectedProfile: StoryProfileDestination?
     @State private var showLikeSheet = false
     @State private var showReport = false
     @State private var showStoryMenu = false
@@ -90,16 +98,14 @@ struct StoryDetailView: View {
                 viewModel.loadLikesForMyStory()
                 isPhotoSwapped = false
             }
-            .navigationDestination(isPresented: Binding(
-                get: { navProfileHandle != nil },
-                set: { if !$0 { navProfileHandle = nil; viewModel.startTimer() } }
-            )) {
-                if let handle = navProfileHandle {
-                    FriendProfileView(
-                        name: viewModel.currentStory.displayName,
-                        handle: handle,
-                        profileImageUrl: viewModel.currentStory.profileImage.isImageURL ? viewModel.currentStory.profileImage : nil
-                    )
+            .navigationDestination(item: $selectedProfile) { profile in
+                FriendProfileView(
+                    name: profile.name,
+                    handle: profile.handle,
+                    profileImageUrl: profile.profileImageUrl
+                )
+                .onDisappear {
+                    viewModel.startTimer()
                 }
             }
             .toolbar(.hidden, for: .navigationBar)
@@ -110,7 +116,17 @@ struct StoryDetailView: View {
                 ReportView(reportType: .STORY, targetId: "\(viewModel.currentStory.storyId)")
             }
             .sheet(isPresented: $showLikeSheet, onDismiss: { viewModel.isPaused = false }) {
-                StoryLikeListSheet(likeUsers: viewModel.likeUsers)
+                StoryLikeListSheet(likeUsers: viewModel.likeUsers) { user in
+                    viewModel.stopTimer()
+                    showLikeSheet = false
+                    DispatchQueue.main.async {
+                        selectedProfile = StoryProfileDestination(
+                            handle: user.handle,
+                            name: user.username,
+                            profileImageUrl: user.profileImageUrl
+                        )
+                    }
+                }
                     .presentationDetents([.medium, .large])
                     .presentationDragIndicator(.visible)
             }
@@ -199,7 +215,11 @@ struct StoryDetailView: View {
                 Button {
                     if story.username != viewModel.myHandle {
                         viewModel.stopTimer()
-                        navProfileHandle = story.username
+                        selectedProfile = StoryProfileDestination(
+                            handle: story.username,
+                            name: story.displayName,
+                            profileImageUrl: story.profileImage.isImageURL ? story.profileImage : nil
+                        )
                     }
                 } label: {
                     HStack(spacing: 12) {

--- a/SNAPY_iOS/Feature/Home/Component/Story/StoryLikeListSheet.swift
+++ b/SNAPY_iOS/Feature/Home/Component/Story/StoryLikeListSheet.swift
@@ -10,6 +10,7 @@ import Kingfisher
 
 struct StoryLikeListSheet: View {
     let likeUsers: [StoryLikeUserData]
+    let onSelectUser: (StoryLikeUserData) -> Void
 
     var body: some View {
         VStack(spacing: 0) {
@@ -29,39 +30,45 @@ struct StoryLikeListSheet: View {
                 ScrollView {
                     LazyVStack(spacing: 0) {
                         ForEach(likeUsers) { user in
-                            HStack(spacing: 12) {
-                                if let url = user.profileImageUrl, let imgUrl = URL(string: url) {
-                                    KFImage(imgUrl)
-                                        .resizable()
-                                        .placeholder { Image("Profile_img").resizable().scaledToFill() }
-                                        .scaledToFill()
-                                        .frame(width: 44, height: 44)
-                                        .clipShape(Circle())
-                                } else {
-                                    Image("Profile_img")
-                                        .resizable()
-                                        .scaledToFill()
-                                        .frame(width: 44, height: 44)
-                                        .clipShape(Circle())
+                            Button {
+                                onSelectUser(user)
+                            } label: {
+                                HStack(spacing: 12) {
+                                    if let url = user.profileImageUrl, let imgUrl = URL(string: url) {
+                                        KFImage(imgUrl)
+                                            .resizable()
+                                            .placeholder { Image("Profile_img").resizable().scaledToFill() }
+                                            .scaledToFill()
+                                            .frame(width: 44, height: 44)
+                                            .clipShape(Circle())
+                                    } else {
+                                        Image("Profile_img")
+                                            .resizable()
+                                            .scaledToFill()
+                                            .frame(width: 44, height: 44)
+                                            .clipShape(Circle())
+                                    }
+
+                                    VStack(alignment: .leading, spacing: 3) {
+                                        Text(user.username)
+                                            .font(.system(size: 15, weight: .semibold))
+                                            .foregroundColor(.textWhite)
+                                        Text("@\(user.handle)")
+                                            .font(.system(size: 13))
+                                            .foregroundColor(.customGray300)
+                                    }
+
+                                    Spacer()
+
+                                    Image(systemName: "heart.fill")
+                                        .font(.system(size: 18))
+                                        .foregroundColor(.red)
                                 }
-
-                                VStack(alignment: .leading, spacing: 3) {
-                                    Text(user.username)
-                                        .font(.system(size: 15, weight: .semibold))
-                                        .foregroundColor(.textWhite)
-                                    Text("@\(user.handle)")
-                                        .font(.system(size: 13))
-                                        .foregroundColor(.customGray300)
-                                }
-
-                                Spacer()
-
-                                Image(systemName: "heart.fill")
-                                    .font(.system(size: 18))
-                                    .foregroundColor(.red)
+                                .contentShape(Rectangle())
+                                .padding(.horizontal, 20)
+                                .padding(.vertical, 10)
                             }
-                            .padding(.horizontal, 20)
-                            .padding(.vertical, 10)
+                            .buttonStyle(.plain)
                         }
                     }
                 }


### PR DESCRIPTION
## 변경 사항
- 앨범 날짜를 일 단위로 정규화하고 자정 이후 오늘 앨범으로 갱신
- 스토리 좋아요 사용자 탭 시 해당 프로필로 이동하고 복귀 시 스토리 재개
- 공개된 과거 앨범과 이번 달 앨범을 합산해 타인 프로필의 게시물 수 표시

## 원인
- 날짜 비교에 시각이 포함되어 자정 이후 다음 날짜 이동이 막혔습니다.
- 좋아요 목록에 프로필 전환 동작이 없었습니다.
- 타인 프로필이 이번 달 피드 개수만 게시물 수에 반영했습니다.

## 검증
- 수정 파일 Swift 문법 검사 통과
- iPhoneOS Debug 빌드 성공 (코드 서명 제외)

Closes #164